### PR TITLE
Packageのインストールは npm ci で実行するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd ~/lesson/nodejs_rps_sample
 3. npm パッケージを取得します
 
 ```
-npm install
+npm ci
 ```
 
 4. プログラムを実行します

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^18.11.13",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
       }
@@ -72,6 +73,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -248,6 +255,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^18.11.13",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
   }


### PR DESCRIPTION
# このPRでやった事

npm packageのインストールは `package-lock.json` が書き換わらない `npm ci` commandで実行したほうが良いと思いましたので、そのようにドキュメントを修正してあります。

最初に自分で `npm ci` を実行したところ、以下のエラーが発生しました。

なので `devDependencies` に `@types/node` の追加も行っています。

```
npm ERR! code EUSAGE
npm ERR!
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR!
npm ERR! Missing: @types/node@18.11.13 from lock file
npm ERR!
npm ERR! Clean install a project
npm ERR!
npm ERR! Usage:
npm ERR! npm ci
npm ERR!
npm ERR! Options:
npm ERR! [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
npm ERR! [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
npm ERR! [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
npm ERR! [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
npm ERR! [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
npm ERR! [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
npm ERR! [-ws|--workspaces] [--include-workspace-root] [--install-links]
npm ERR!
npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
npm ERR!
npm ERR! Run "npm help ci" for more info

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kogakeita/.npm/_logs/2022-12-11T07_40_31_304Z-debug-0.log
zsh: exit 1     npm ci
```

# このPRの目的

元々READMEには `npm install` を実行するように書いてありましたが、この方法だと `package-lock.json` が書き変わってしまい各自でPackageのバージョンが異なってしまう事が原因でペアプロが上手く進まなくなる可能性を排除する為に実施しました。

# レビュアーに特に確認してもらいたい内容

方針に問題ないかご確認をお願いします。